### PR TITLE
Update SAF_FBK.lp 'Supply Fan Feedback Looping Program

### DIFF
--- a/SAF_FBK.lp 'Supply Fan Feedback Looping Program
+++ b/SAF_FBK.lp 'Supply Fan Feedback Looping Program
@@ -5,7 +5,6 @@ Numeric Output SAF_SPD
 Numeric Output SAF_FBK_HZ
 Numeric Output SAF_F_OFF
 Numeric Output SAF_F_ON
-Numeric   FailStamp
 '****************************************
 'Author:  Nabin Maharjan
 'Date:  
@@ -13,9 +12,10 @@ Numeric   FailStamp
 'Flow Type:  Looping
 'Triggers:  N/A
 '**************************************** 
-Datetime LastTime 'last time PID was calculated
+Datetime LastTime 'last time fail was calculated
+Datetime FailStamp
 
-Initialize: 'initialize PID parameters
+Initialize: 'initialize parameters
   LastTime = Date
   FailStamp = Date
   Goto FanFbk
@@ -33,9 +33,9 @@ FanFbk:
     Turn Off SAF_F_OFF
   Endif
   
-    If not SAF_CMD and SAF_RI then
+  If not SAF_CMD and SAF_RI then
     If Date > FailStamp + 180 then
-    Turn On SAF_F_ON
+      Turn On SAF_F_ON
     Endif
   Else
     FailStamp = Date


### PR DESCRIPTION
As I pointed out in the Teams chat on 7/29/20, the FailStamp being defined as a simple Numeric will cause an error (at least when the script is run on an i2 or b3 controller in EBO).  The program will immediately go to the E line when attempting to initialize (FailStamp = Date).  This prevents the program from ever getting to FanFbk where SAF_RI is set.  As a result, SAF_RI (or SaFanSts for the new point naming) will never get set and any programs where this signal is required, will not execute as expected.  I simply defined SAF_RI as a Datetime rather than a Numeric and it seems to resolve the issue in EBO.